### PR TITLE
Bug fix cache state debug info

### DIFF
--- a/src/Utils/DebugInfo.php
+++ b/src/Utils/DebugInfo.php
@@ -54,7 +54,7 @@ class DebugInfo
             return ' &#013;Cache: is globally turned off (You should put "enable_cache" => true in config\widgetize.php) ';
         }
 
-        return " &#013;Cache : {$this->widget->cacheLifeTime} (min)' ";
+        return " &#013;Cache : {$this->widget->cacheLifeTime} (min) ";
     }
 
     private function addHtmlComments()


### PR DESCRIPTION
Fixed a bug: trailing ' in cache state debug information removed

Preview of bug in generated HTML:
![screen shot 2018-09-11 at 11 49 48](https://user-images.githubusercontent.com/1402868/45352675-538b1080-b5b9-11e8-8281-3e22219091a5.png)

Fixed by simply removing the trailing ' in DebugInfo.php